### PR TITLE
fixed two non-printable characters that should have been spaces which caused the DynJS parser to malfunction

### DIFF
--- a/src/main/resources/vertx/buffer.js
+++ b/src/main/resources/vertx/buffer.js
@@ -146,7 +146,7 @@ var Buffer = function(obj) {
   this.getString = function(start, end, enc) {
     if (typeof enc === 'undefined') {
       return __jbuf.getString(start, end);
-    } else {
+    } else  {
       return __jbuf.getString(start, end, enc);
     }
   };
@@ -228,7 +228,7 @@ var Buffer = function(obj) {
     if (typeof enc === 'undefined') {
       __jbuf.appendString(str);
 
-    } else {
+    } else  {
       __jbuf.appendString(str, enc);
     }
     return this;


### PR DESCRIPTION
The file vertx/buffer.js contained non-printable characters at two places. These caused the DynJS parser to not function properly resulting in SyntaxErrors. I fixed the characters using a hex editor and checked it is working properly afterwards.

Notice, the lang-js.jar snapshot available at Sonartype is not functional at the time of writing. I'm running Windows, other OSes might behave differently, eventually eating the characters...
