### PR TITLE
Authorize hook should return false by default

### DIFF
--- a/src/main/resources/vertx/sockjs.js
+++ b/src/main/resources/vertx/sockjs.js
@@ -178,7 +178,7 @@ sockJS.SockJSServer = function(httpServer) {
       handleSocketCreated: lookup('socket-created', true),
       handlePreRegister  : lookup('pre-register',   true),
       handleUnRegister   : lookup('unregister',     true),
-      handleAuthorise    : lookup('authorize',      true),
+      handleAuthorise    : lookup('authorize',      false),
       handlePostRegister : lookup('post-register'),
       handleSocketClosed : lookup('socket-closed')
     }));


### PR DESCRIPTION
EventBusBridgeHook defines that handleAuthorise should return true if the hook wants to override the authorize behavior. I believe the default behavior should be not to override the internal authorize logic.
