### PR TITLE
Add method to retrieve the buffer as a byte array

### DIFF
--- a/src/main/resources/vertx/buffer.js
+++ b/src/main/resources/vertx/buffer.js
@@ -85,6 +85,15 @@ var Buffer = function(obj) {
   };
 
   /**
+   * Get a copy of the buffer as a byte array.
+   *
+   * @returns {array}
+   */
+  this.getBytes = function() {
+      return __jbuf.getBytes();
+  };
+
+  /**
    * Get a signed 32 bit integer from the buffer.
    *
    * @param {number} pos the position


### PR DESCRIPTION
In order to Base64 encode a vertx buffer in JavaScript I needed a way to retrieve the whole buffer as a byte array in one go.
