### PR TITLE
Use `handler.call()` instead of `handler()` on read streams.

### DIFF
--- a/src/main/resources/vertx/streams.js
+++ b/src/main/resources/vertx/streams.js
@@ -170,7 +170,7 @@ var ReadSupport = function(delegate) {
    */
   this.dataHandler = function(handler) {
     delegate.dataHandler(function(buf) {
-      handler(new Buffer(buf));
+      handler.call(handler, new Buffer(buf));
     });
     return this;
   };


### PR DESCRIPTION
This is primarily for compatibility with vertx/parse_tools.Parser
which needs to act like both an object and a function, and to do
so, overrides `Object.prototype.call`. None of this is really ideal
and the API should probably be re-evaluted for the next major release.

This change should have been included in 235bd16 but was overlooked.
